### PR TITLE
Roles management masonry effect

### DIFF
--- a/permafrost/__version__.py
+++ b/permafrost/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.8"
+VERSION = "0.2.9"

--- a/permafrost/templates/permafrost/permafrostrole_manage.html
+++ b/permafrost/templates/permafrost/permafrostrole_manage.html
@@ -77,12 +77,9 @@
 
         {% regroup permissions by content_type as content_type_list %}
 
-        {% for content_type, permission_list in content_type_list %}
-        {% cycle 'odd' 'even' as col silent %}
-        {% if col == 'odd' %}
-        <div class="row"> {# start .row #}
-            {% endif %}
-            <div class="col-sm">
+        <div class="masonry d-flex flex-column flex-wrap h-100"> 
+            {% for content_type, permission_list in content_type_list %}
+            <div class="masonry-brick w-50 mb-3 mr-3 d-inline-block">
                 <p class="text-capitalize small font-weight-bold mb-1 text-gray-600">{{ content_type.name }}</p>
                 <p>
                     {% for permission in permission_list %}
@@ -92,20 +89,18 @@
                     {% endif %}
                     {% endfor %}
                 </p>
-
             </div>
-            {% if col == 'even' or forloop.last %}
-        </div> {# end .row #}
-        {% endif %}
+            {% endfor %}
 
-        {% if forloop.last %}
-        {% resetcycle col %}
-        {% endif %}
-        {% endfor %}
-
+        </div> 
         {% endif %}
     </div>
 </div>
+<style>
+    .vh-75 {
+        height: 82vh;
+    }
+</style>
 {% endblock %}
 {% block extra_js %}
 

--- a/permafrost/templates/permafrost/permafrostrole_manage.html
+++ b/permafrost/templates/permafrost/permafrostrole_manage.html
@@ -7,7 +7,7 @@
 
 <h1 class="my-3 text-gray-800">{% trans 'Roles & Permissions' %}</h1></a>
 
-<div class="row no-gutters shadow bg-white vh-75">
+<div class="row no-gutters shadow bg-white vh-main">
     <div class="col-3 d-flex flex-column flex-shrink-0 h-100 px-2 border-right-gray-300">
 
         {% comment %}
@@ -96,11 +96,6 @@
         {% endif %}
     </div>
 </div>
-<style>
-    .vh-75 {
-        height: 82vh;
-    }
-</style>
 {% endblock %}
 {% block extra_js %}
 


### PR DESCRIPTION
Adds a ["masonry"](https://w3bits.com/labs/flexbox-masonry/2/) effect for lists/divs of variable heights


```
(pf) ➜  develop git:(roles-management-masonry-effect) ./manage.py test permafrost

Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..............................................
----------------------------------------------------------------------
Ran 46 tests in 7.680s

OK
```

<img width="737" alt="Screen Shot 2020-12-16 at 1 27 40 PM" src="https://user-images.githubusercontent.com/50152349/102354474-87c4b700-3fa2-11eb-937e-50929e276d10.png">
