### PR TITLE
Refactor permissions multiselect check boxes

### DIFF
--- a/permafrost/templates/permafrost/permafrostrole_form.html
+++ b/permafrost/templates/permafrost/permafrostrole_form.html
@@ -32,7 +32,7 @@
             {{ form.non_field_errors }}
             <div class="form-row">
                 <div class="form-group col-12 col-md-4">
-                    <label for="{{ form.name.id_for_label }}">
+                    <label class="text-gray-300" for="{{ form.name.id_for_label }}">
                         {{ form.name.label }}
                     </label>
                     {% if form.name.required %}<span class="required">*</span>{% endif %}
@@ -41,7 +41,7 @@
                         type="text" 
                         id="{{form.name.id_for_label}}" 
                         class="form-control{% if form.name.errors %} is-invalid{% endif %}" 
-                        placeholder="{{ form.name.help_text }}" value="{{form.instance.name}}" >
+                        placeholder="{{ form.name.help_text }}" value="{% firstof form.initial.name form.data.name form.instance.name '' %}" >
                     
                     {% if form.name.errors %}
                         <div class="invalid-feedback">
@@ -55,7 +55,7 @@
             </div>
             <div class="form-row">
                 <div class="form-group col">
-                    <label for="{{ form.description.id_for_label }}">
+                    <label class="text-gray-300" for="{{ form.description.id_for_label }}">
                         {{ form.description.label }}
                     </label>
                     {% if form.description.required %}<span class="required">*</span>{% endif %}
@@ -64,11 +64,7 @@
                         type="text" id="{{ form.description.id_for_label }}" 
                         class="form-control{% if form.name.errors %} is-invalid{% endif %}" 
                         placeholder="{{ form.description.help_text }}"
-                        {% if form.instance.description %}
-                        value="{{form.instance.description}}"
-                        {% else %}
-                         value=""   
-                        {% endif %}>
+                        value="{% firstof form.initial.description form.data.description form.instance.description '' %}" >
 
                     {% if form.description.errors %}
                         <div class="invalid-feedback">
@@ -81,36 +77,68 @@
             </div>
             <div class="form-row">
                 <div class="form-group col-12 col-md-4">
-                    <label for="{{ form.description.id_for_label }}">
-                        {{ form.description.label }}
+                    <label class="text-gray-300" for="{{ form.category.id_for_label }}">
+                        {{ form.category.label }}
                     </label>
-                    {% if form.description.required %}<span class="required">*</span>{% endif %}
+                    {% if form.category.required %}<span class="required">*</span>{% endif %}
                     
                     {{ form.category }}
 
-                    {% if form.description.errors %}
+                    {% if form.category.errors %}
                         <div class="invalid-feedback">
-                            {% for error in form.description.errors %}
+                            {% for error in form.category.errors %}
                                 {{ error }}
                             {% endfor %}
                         </div>
                     {% endif %}
                 </div>
             </div>
-            <!-- {% for field in form %}
-                <div class="fieldWrapper form-group" aria-required={% if field.field.required %}"true"{% else %}"false"{% endif %}>
-                    {{ field.label_tag }}{% if field.field.required %}<span class="required">*</span>{% endif %}
-                    {{ field }}
-                    {{ field.errors }}
+            <div class="form-row border-bottom-gray-300">
+                <p class="col-6 font-weight-bold">{% trans 'Required Permissions' %}</p>
+                <p class="col-6 font-weight-bold">{% trans 'Optional Permissions' %}</p>
+            </div>
+            <div class="form-row">
+                {% if form.permissions.errors %}
+                    <div class="invalid-feedback">
+                        {% for error in form.permissions.errors %}
+                            {{ error }}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            </div>
+            {% for content_type, category in permission_categories.items %}
+                <div class="form-row">
+                    <p class="small font-weight-bold col-12 text-gray-600 mt-3">{{ category.name }}</p>
+                    <div class="col-6">
+                        {% for permission in category.required %}
+                        <div class="d-flex align-items-center">
+                            <span>{{ permission.name }}</span>
+                            <i class="fas fa-info-circle text-gray-600" aria-label="{% trans 'Info' %}"></i>
+                            <i class="ml-auto fas fa-lock text-gray-600" aria-label="{% trans 'Default Permission' %}"></i>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    <div class="col-6">
+                        {% for permission in category.optional %}
+                        <div class="d-flex align-items-center">
+                            <span>{{ permission.name }}</span>
+                            <i class="fas fa-info-circle text-gray-600" aria-label="{% trans 'Info' %}"></i>
+                            <input 
+                                class="ml-auto" 
+                                type="checkbox" 
+                                name="{{ form.permissions.name }}" 
+                                value="{{ permission.id }}"
+                                {% if permission.selected %} checked{% endif %}
+                            >
+                        </div>
+                        {% endfor %}
+                    </div>
                 </div>
-            {% endfor %} -->
-        
+            {% endfor %}
         </div>
-
     </div>
 </form>
 {% endblock %}
-
 
 {% block extra_js %}
     {% if not object %} {# "Hide JS change handler on edit " #}

--- a/permafrost/tests.py
+++ b/permafrost/tests.py
@@ -611,16 +611,14 @@ class PermafrostFormClassTests(TestCase):
         
         self.assertIn('permissions', form.fields)
 
-        self.assertEqual(form.fields['permissions'].queryset, Permission.objects.filter(id__in=[37,38]))
+        self.assertEqual(list(form.fields['permissions'].queryset), list(Permission.objects.filter(id__in=[37,38])))
         
         form_2 = PermafrostRoleCreateForm(initial={'category':'administration'})
         
-        self.assertEqual(form_2.fields['permissions'].queryset, Permission.objects.filter(id__in=[39]))
-        
+        self.assertEqual(list(form_2.fields['permissions'].queryset), list(Permission.objects.filter(id__in=[39])))
         form_3 = PermafrostRoleCreateForm(initial={'category':'user'})
         
-        self.assertEqual(form_3.fields['permissions'].queryset, Permission.objects.filter(id__in=[40]))
-
+        self.assertEqual(list(form_3.fields['permissions'].queryset), list(Permission.objects.filter(id__in=[40])))
 
     def test_update_form_category_is_read_only_and_disabled(self):
         form = PermafrostRoleUpdateForm(instance=self.pf_role)

--- a/permafrost/tests.py
+++ b/permafrost/tests.py
@@ -437,7 +437,11 @@ class PermafrostViewTests(TestCase):
             self.assertContains(response, 'name="name"')
             self.assertContains(response, 'name="description"')
             self.assertContains(response, 'name="category"')
-            self.assertContains(response, 'name="deleted"')
+            self.assertContains(response, 'name="permissions"')
+            
+            ## add deleted field down the line
+            # self.assertContains(response, 'name="deleted"')
+            
             self.assertIsInstance(response.context['form'], PermafrostRoleUpdateForm)
         except:
             print("")
@@ -454,6 +458,33 @@ class PermafrostViewTests(TestCase):
         response = self.client.get(uri)
         self.assertTemplateUsed(response, 'permafrost/base.html')
         self.assertTemplateUsed(response, 'permafrost/permafrostrole_form.html')
+
+    def test_update_form_has_selected_optional_permission(self):
+        ## add optional permissions
+        self.pf_role.permissions_set(Permission.objects.filter(codename__in=['add_permafrostrole', 'change_permafrostrole']))
+        
+        uri = reverse('permafrost:role-update', kwargs={'slug': 'test-role'})
+        response = self.client.get(uri)
+        try:
+            self.assertContains(response, """<input 
+                                class="ml-auto" 
+                                type="checkbox" 
+                                name="permissions" 
+                                value="37"
+                                 checked
+                            >""")
+            self.assertContains(response, """<input 
+                                class="ml-auto" 
+                                type="checkbox" 
+                                name="permissions" 
+                                value="38"
+                                 checked
+                            >""")
+        except:
+            print("")
+            print(response.content.decode())
+            print("")
+            raise
     
     def test_role_detail_GET_returns_404_if_not_on_current_site(self):
         uri = reverse('permafrost:role-update', kwargs={'slug': 'administrator'})


### PR DESCRIPTION
Previously the select boxes were grouped by optional vs required. Within each group those were broken down by content type.

They are now be grouped by content type and broken out into required column and an optional column

This refactor simplifies some of the form processing and sorts the permissions options in the view class