### PR TITLE
fix dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             'wheel',
             'twine',
             'm2r',
+            'mistune<2.0.0',
         ],
         'docs': [                           # Packages needed to generate docs
             'recommonmark',


### PR DESCRIPTION
restrict mistune's package version to below 2.0.0 to avoid error with m2r installation